### PR TITLE
Fix TypeScript error: a 'declare' modifier cannot be used in an already ambient context.

### DIFF
--- a/iso-8859-15.d.ts
+++ b/iso-8859-15.d.ts
@@ -6,11 +6,11 @@ declare module 'iso-8859-15' {
     mode: 'fatal' | 'replacement';
   };
 
-  export declare function encode(
+  export function encode(
     text: string,
     options?: EncodeOptions
   ): Uint16Array;
-  export declare function decode(
+  export function decode(
     buffer: Uint16Array | Uint8Array | Buffer | string,
     options?: DecodeOptions
   ): string;

--- a/src/iso-8859-15.d.ts
+++ b/src/iso-8859-15.d.ts
@@ -6,11 +6,11 @@ declare module 'iso-8859-15' {
     mode: 'fatal' | 'replacement';
   };
 
-  export declare function encode(
+  export function encode(
     text: string,
     options?: EncodeOptions
   ): Uint16Array;
-  export declare function decode(
+  export function decode(
     buffer: Uint16Array | Uint8Array | Buffer | string,
     options?: DecodeOptions
   ): string;


### PR DESCRIPTION
By removing the extra `declare` keywords.